### PR TITLE
fix: correct @return docs for build_ppi_network()

### DIFF
--- a/R/ppi_network.R
+++ b/R/ppi_network.R
@@ -11,7 +11,8 @@
 #' @param processed_dir Character string specifying directory path for processed data files (default: "./")
 #' @param species Character string specifying species taxonomy ID (default: "9606")
 #'
-#' @return An igraph object representing the PPI network
+#' @return A named list of igraph objects, one per data source (e.g., \code{string}, \code{biogrid}, \code{intact}).
+#'   Use \code{\link{merge_ppi_networks}} to combine them into a single network.
 #'
 #' @export
 #'

--- a/man/build_ppi_network.Rd
+++ b/man/build_ppi_network.Rd
@@ -27,7 +27,8 @@ build_ppi_network(
 \item{species}{Character string specifying species taxonomy ID (default: "9606")}
 }
 \value{
-An igraph object representing the PPI network
+A named list of igraph objects, one per data source (e.g., \code{string}, \code{biogrid}, \code{intact}).
+  Use \code{\link{merge_ppi_networks}} to combine them into a single network.
 }
 \description{
 Construct protein-protein interaction network from multiple data sources using unified interface


### PR DESCRIPTION
## Summary

Corrects the `@return` documentation for `build_ppi_network()` to accurately describe the actual return type.

## Problem

The current documentation states:
```r
@return An igraph object representing the PPI network
```

But the function actually returns a **named list** of igraph objects (one per data source), not a single igraph object. This is evident from the code at line 106:
```r
return(networks)  # networks is a named list
```

## Changes

### `R/ppi_network.R` (roxygen source)
Updated `@return` tag to:
```r
@return A named list of igraph objects, one per data source (e.g., \code{string}, \code{biogrid}, \code{intact}).
  Use \code{\link{merge_ppi_networks}} to combine them into a single network.
```

### `man/build_ppi_network.Rd` (generated man page)
Updated `\value` section to match the roxygen source.

## Testing

- R syntax validation: `parse()` — clean
- No functional changes; documentation-only fix
- Existing tests unaffected

## Related Issues

Fixes #25

---
*Documentation fix from upstream R package agent*